### PR TITLE
Update starting point for nonconvex

### DIFF
--- a/nonconvex.jl
+++ b/nonconvex.jl
@@ -82,20 +82,22 @@ function solve_opf(file_name)
         br_angmax[i] = branch["angmax"]
     end
 
+    # Variable starting point impacts correctness of AD (as of, Nonconvex v2.0.2, NonconvexIpopt v0.4.0)
+    # but using non-zero starting values appears to work
     for (i,bus) in ref[:bus]
-        addvar!(model, "va_$(i)", -Inf, Inf) #va
+        addvar!(model, "va_$(i)", -Inf, Inf, init=1.0) #va
         addvar!(model, "vm_$(i)", bus["vmin"], bus["vmax"], init=1.0) #vm
     end
 
     for (i,gen) in ref[:gen]
-        addvar!(model, "pg_$(i)", gen["pmin"], gen["pmax"]) #pg
-        addvar!(model, "qg_$(i)", gen["qmin"], gen["qmax"]) #qg
+        addvar!(model, "pg_$(i)", gen["pmin"], gen["pmax"], init=1.0) #pg
+        addvar!(model, "qg_$(i)", gen["qmin"], gen["qmax"], init=1.0) #qg
     end
 
     for (l,i,j) in ref[:arcs]
         branch = ref[:branch][l]
-        addvar!(model, "p_$(l)_$(i)_$(j)", -branch["rate_a"], branch["rate_a"]) #p
-        addvar!(model, "q_$(l)_$(i)_$(j)", -branch["rate_a"], branch["rate_a"]) #q
+        addvar!(model, "p_$(l)_$(i)_$(j)", -branch["rate_a"], branch["rate_a"], init=1.0) #p
+        addvar!(model, "q_$(l)_$(i)_$(j)", -branch["rate_a"], branch["rate_a"], init=1.0) #q
     end
 
 


### PR DESCRIPTION
@mohamed82008, digging into the issue of the Ipopt being different I found my hunch was correct and the starting point was the source of the discrepancy.  I had presumed the default starting value for variables in Nonconvex was `0.0`, however it appears to be the variables lower bound, unless it is unbounded in which case it is 0.0.

I tried updating the same starting point used in the other models (all variables start at 0.0, except `vm` which is set to 1.0).  This change broke the implementation and Ipopt would not converge.  I presume due to the point discussed here, https://github.com/JuliaNonconvex/Nonconvex.jl/issues/140

Using starting values of 1.0 for all variables seemed to be a reasonable compromise as the solver converged in a similar number of iterations to what is expected.

CC @odow 