### PR TITLE
Maybe Manopt?

### DIFF
--- a/debug/manopt-mwe.jl
+++ b/debug/manopt-mwe.jl
@@ -1,0 +1,64 @@
+# See also
+# https://juliamanifolds.github.io/ManoptExamples.jl/stable/examples/Rosenbrock/
+# and
+# https://manoptjl.org/stable/tutorials/ConstrainedOptimization/
+
+#
+# Trying to reproduce the Optim.jl MWE
+#
+
+using Manopt, Manifolds
+
+# Rosenbrock cost
+f(M,x) = (1.0 - x[1])^2 + 100.0 * (x[2] - x[1]^2)^2
+
+# the gradient can be improved by using an in-place one
+# one could also use a scheme with AD like
+# https://manoptjl.org/stable/tutorials/AutomaticDifferentiation/
+# or really just AD, since we are Euclidean
+function grad_f(M,x)
+    return [
+        -2*(1.0-x[1]) - 400*(x[2] - x[1]^2)*x[1],
+        200.0*(x[2]-x[1]^2)
+    ]
+end
+
+x0 = [0.25, 0.25]
+M = Euclidean(2)
+
+# Then one can for example use
+x1 = quasi_Newton(M, f, grad_f, x0)
+# Or look at some output as well
+quasi_Newton(M, f, grad_f, x0;
+    debug=[:Iteration, :Cost, " ", :GradientNorm, "\n", 10, :Stop],
+    return_state=true
+)
+# Or even change the stopping criterion
+quasi_Newton(M, f, grad_f, x0;
+    debug=[:Iteration, :Cost, " ", :GradientNorm, "\n", 10, :Stop],
+    stopping_criterion = StopAfterIteration(1000) | StopWhenGradientNormLess(1e-9),
+    return_state=true
+)
+
+
+# Constraints
+# I do not understand what the constraints in the Optim.jl MWE mean,
+# TwiceDifferentiableConstraints is no documented,
+# * so I _guess_ lx and ux are upper and lower bounds for x?
+# * what are lc and uc? Upper and lower bounds ... for...?
+
+# So for now just the two constraints that I do understand
+# at least I hope that they are meant <= 0 ?
+# If we need upper and lower bounds we would have to hardcode them here,
+# i.e. two lines each
+function g(M,x)
+    return [
+        x[1]^2 + x[2]^2,
+        x[2]*sin(x[1])-x[1]
+    ]
+end
+
+# alternatively one could also implement them separately
+# Then the ALM we have does need the gradient of G of course
+
+augmented_Lagrangian_method(M, f, grad_f; g=g, grad_g=???)


### PR DESCRIPTION
For now this is just a first sketch of an MWE, because neither Optim nor the MWEs here gave me enough understanding in what they actually solve. None of the variables is speaking, none of the functions is documented – so after about an hour I gave up trying to reverse-engineer what even the 2D example should do.

So this MWE for now just illustrates two quasi Newton Calls and has a lot of comments on what ALM might do.

If we would get an understanding of the constraints, it would be best to implement each (that is each real valued) constraint as its own function, the same for their gradients and pass these to `g=` and `grad_g=` of the augmented Lagrangian, cf the docs at

https://manoptjl.org/stable/solvers/augmented_Lagrangian_method/

Things to keep in mind: This will probably just take last place, for a very simple reason – constraint optimisation is – as far as I am aware of – not that old on manifolds yet, see the paper where the ALM is from https://link.springer.com/article/10.1007/s00245-019-09564-3 its from 2020. So this solver does have manifolds in mind in its generality and compared to IPNweton or such (faster and more tailored towards Euclidean problems), this will probably just be super slow.

Also box constraints or such are not socially treated – for actually the same reason, that all this is relatively new stuff on Manifolds. So for $a \leq x \ leq b$ we would actually need two constraints to be implemented. There is also no tools (unless you use some AD from somewhere else) to give you the gradients. Even not for linear constraints, since on Manifolds – linearity does not exist (unless you are Euclidean)

If this is too rough in an idea to add Manopt.jl I can also understand if we just close this.
